### PR TITLE
shell path problems

### DIFF
--- a/ilogue/fexpect/internals.py
+++ b/ilogue/fexpect/internals.py
@@ -37,8 +37,8 @@ def createScript(cmd):
         s+= '"{0}",'.format(e[0])
     s+= ']\n'
     #start
-    spwnTem = """child = pexpect.spawn('/bin/{shell} "{cmd}"',timeout={to})\n"""
-    s+= spwnTem.format(shell=useShell,cmd=cmd,to=to)
+    spwnTem = """child = pexpect.spawn('{shellPrefix}{shell} "{cmd}"',timeout={to})\n"""
+    s+= spwnTem.format(shell=useShell,cmd=cmd,to=to,shellPrefix=('' if useShell.startswith('/') else '/bin/'))
     s+= "child.logfile = sys.stdout\n"
     s+= "while True:\n"
     s+= "\ttry:\n"


### PR DESCRIPTION
This change fixes problems I saw where my fabric shell was already an absolute path that I wanted to use, but it was trying to prepend '/bin/', making an invalid shell path of '/bin//bin/bash' when I tried to execute sudo commands.
