### PR TITLE
Support for calling run/sudo/local both inside and outside 'with expecting(..)' block.

### DIFF
--- a/ilogue/fexpect/api.py
+++ b/ilogue/fexpect/api.py
@@ -11,17 +11,23 @@ def expecting(e):
     return ExpectationContext(e)
 
 def run(cmd, **kwargs):
-    #run wrapper
-    wrappedCmd = wrapExpectations(cmd)
-    return fabric.api.run(wrappedCmd, **kwargs)
+    #run wrapper 
+    if 'expectations' in fabric.state.env and \
+        len(fabric.state.env.expectations) > 0:
+        cmd = wrapExpectations(cmd)
+    return fabric.api.run(cmd, **kwargs)
 
 def sudo(cmd, **kwargs):
     #sudo wrapper
-    wrappedCmd = wrapExpectations(cmd)
-    return fabric.api.sudo(wrappedCmd, **kwargs)
+    if 'expectations' in fabric.state.env and \
+        len(fabric.state.env.expectations) > 0:
+        cmd = wrapExpectations(cmd)
+    return fabric.api.sudo(cmd, **kwargs)
 
 def local(cmd, **kwargs):
     #local wrapper
-    wrappedCmd = wrapExpectations(cmd)
-    return fabric.api.local(wrappedCmd, **kwargs)
+    if 'expectations' in fabric.state.env and \
+        len(fabric.state.env.expectations) > 0:
+        cmd = wrapExpectations(cmd)
+    return fabric.api.local(cmd, **kwargs)
 

--- a/ilogue/fexpect/internals.py
+++ b/ilogue/fexpect/internals.py
@@ -40,7 +40,7 @@ def createScript(cmd):
         s+= '"{0}",'.format(e[0])
     s+= ']\n'
     #start
-    spwnTem = """child = pexpect.spawn('{shellPrefix}{shell} "{cmd}"',timeout={to})\n"""
+    spwnTem = """child = pexpect.spawn(\"\"\"{shellPrefix}{shell} "{cmd}" \"\"\",timeout={to})\n"""
     s+= spwnTem.format(shell=useShell,cmd=cmd,to=to,shellPrefix=('' if useShell.startswith('/') else '/bin/'))
     s+= "child.logfile = sys.stdout\n"
     s+= "while True:\n"

--- a/ilogue/fexpect/tests.py
+++ b/ilogue/fexpect/tests.py
@@ -95,6 +95,28 @@ class FexpectTests(unittest.TestCase):
         self.assertIn('Hi Bill.',output2)
         self.assertIn('6',output3)
 
+    def test_quotes(self):
+        cmd1 = 'read -p "Prompt1:" RESP1 && echo Received $RESP1.'
+        cmd2 = "read -p 'Prompt2:' RESP2 && echo Received $RESP2."
+        cmd3 = """read -p 'Prompt3:' -n "20" RESP3 && echo Received $RESP3."""
+
+        from ilogue.fexpect import expect, expecting, run
+        import fabric
+
+        expectation =  []
+        expectation += expect('Prompt1:','Foo')
+        expectation += expect('Prompt2:','Bar')
+        expectation += expect('Prompt3:','Baz')
+
+        with expecting(expectation):
+            output1 = run(cmd1)
+            output2 = run(cmd2)
+            output3 = run(cmd3)
+
+        self.assertIn('Received Foo',output1)
+        self.assertIn('Received Bar',output2)
+        self.assertIn('Received Baz',output3)
+
     def tryOrFailOnPrompt(self,method,args):
         try:
             with settings(abort_on_prompts=True):

--- a/ilogue/fexpect/tests.py
+++ b/ilogue/fexpect/tests.py
@@ -77,6 +77,24 @@ class FexpectTests(unittest.TestCase):
         fabric.state.env = backupenv
         self.assertIn('00 sh',output)
 
+    def test_mixed_case(self):
+        cmd1 = 'expr 5 + 5'
+        cmd2 = 'read -p Name: NAME && echo Hi $NAME.'
+        cmd3 = 'expr 18 / 3'
+
+        from ilogue.fexpect import expect, expecting, run
+        import fabric
+
+        output1 = run(cmd1)
+        expectation =  expect('Name:','Bill')
+        with expecting(expectation):
+            output2 = run(cmd2)
+        output3 = run(cmd3)
+
+        self.assertIn('10',output1)
+        self.assertIn('Hi Bill.',output2)
+        self.assertIn('6',output3)
+
     def tryOrFailOnPrompt(self,method,args):
         try:
             with settings(abort_on_prompts=True):


### PR DESCRIPTION
Currently, if you call run() outside of a 'with expecting(..)' block, you get a traceback that says that fabric.state.env.expectations hasn't been defined. This is happening because fexpect wraps _every_ command it receives with 'expect code' which depends on expectations being set. Commands should only be wrapped if they are called inside of a 'with expecting(..) block.' 

This patch adds some conditional logic to api.py to determine whether or not to wrap a command with 'expect code' before invoking fabric's run/sudo/local methods. It also provides a test demonstrating the ability to call run both inside and outside of a 'with expecting(..)' block.

This patch should address the issue mentioned by jberryman here:
https://github.com/ilogue/fexpect/issues/8
