### PR TITLE
Fixed the failure of import pexpect in Windows.

### DIFF
--- a/ilogue/fexpect/internals.py
+++ b/ilogue/fexpect/internals.py
@@ -15,7 +15,7 @@ def wrapExpectations(cmd):
     script = createScript(cmd)
     remoteScript = '/tmp/fexpect_'+shortuuid.uuid()
     import imp
-    pexpect_module = imp.find_module('pexpect')[1]
+    _, pexpect_module, _ = imp.find_module('pexpect')
     if pexpect_module.endswith('.pyc'):
         pexpect_module = pexpect_module[:-1]
     # If mode not set explicitly, and this is run as a privileged user, 

--- a/ilogue/fexpect/internals.py
+++ b/ilogue/fexpect/internals.py
@@ -14,8 +14,8 @@ class ExpectationContext(object):
 def wrapExpectations(cmd):
     script = createScript(cmd)
     remoteScript = '/tmp/fexpect_'+shortuuid.uuid()
-    import pexpect
-    pexpect_module = pexpect.__file__
+    import imp
+    pexpect_module = imp.find_module('pexpect')[1]
     if pexpect_module.endswith('.pyc'):
         pexpect_module = pexpect_module[:-1]
     # If mode not set explicitly, and this is run as a privileged user, 


### PR DESCRIPTION
pexpect module does not support Windows, import will fail.
But because it is not required other than absolute path,
use the imp.find_module instead.
