### PR TITLE
Add show_response flag to expecting.

### DIFF
--- a/ilogue/fexpect/api.py
+++ b/ilogue/fexpect/api.py
@@ -7,8 +7,8 @@ def expect(promptexpr, response, exitAfter=-1):
         return [(promptexpr, response, exitAfter)]
     return [(promptexpr, response)]
 
-def expecting(e):
-    return ExpectationContext(e)
+def expecting(e, show_response=True):
+    return ExpectationContext(e, show_response)
 
 def run(cmd, **kwargs):
     #run wrapper

--- a/ilogue/fexpect/internals.py
+++ b/ilogue/fexpect/internals.py
@@ -4,12 +4,15 @@ import fabric
 
 
 class ExpectationContext(object):
-    def __init__(self,expectations):
+    def __init__(self, expectations, show_response):
         self.expectations = expectations
+        self.show_response = show_response
     def __enter__(self):
         fabric.state.env.expectations = self.expectations
+        fabric.state.env.show_response = self.show_response
     def __exit__(self, type, value, tb):
         fabric.state.env.expectations = []
+        fabric.state.env.show_response = True
 
 def wrapExpectations(cmd):
     script = createScript(cmd)
@@ -42,7 +45,8 @@ def createScript(cmd):
     #start
     spwnTem = """child = pexpect.spawn('{shellPrefix}{shell} "{cmd}"',timeout={to})\n"""
     s+= spwnTem.format(shell=useShell,cmd=cmd,to=to,shellPrefix=('' if useShell.startswith('/') else '/bin/'))
-    s+= "child.logfile = sys.stdout\n"
+    logfile = 'logfile' if fabric.state.env.show_response else 'logfile_read'
+    s+= "child.{0} = sys.stdout\n".format(logfile)
     s+= "while True:\n"
     s+= "\ttry:\n"
     s+= "\t\ti = child.expect(expectations)\n"

--- a/ilogue/fexpect/tests.py
+++ b/ilogue/fexpect/tests.py
@@ -84,3 +84,20 @@ class FexpectTests(unittest.TestCase):
         except SystemExit as promptAbort:
             self.fail("There was an unexpected (password) prompt.")
         return result 
+
+    def test_show_response(self):
+        cmd = 'echo "Hello" && read -s NAME'
+        from ilogue.fexpect import expect, expecting, run
+        expectation =  expect('Hello','answer')
+        with expecting(expectation, True):
+            output = run(cmd)
+        self.assertIn('answer',output)
+
+    def test_hide_response(self):
+        cmd = 'echo "Hello" && read -s NAME'
+        from ilogue.fexpect import expect, expecting, run
+        expectation =  expect('Hello','answer')
+        with expecting(expectation, False):
+            output = run(cmd)
+        self.assertNotIn('answer',output)
+


### PR DESCRIPTION
It is possible to hide in when responding secret data such as passwords,
if you turn off this flag.
