### PR TITLE
Fix the test to fail

### DIFF
--- a/ilogue/fexpect/tests.py
+++ b/ilogue/fexpect/tests.py
@@ -66,15 +66,15 @@ class FexpectTests(unittest.TestCase):
         self.assertIn('answer',output)
 
     def test_can_change_shell(self):
-        cmd = 'ps && echo "Hello" && read NAME && echo "Hi $NAME."'
+        cmd = 'ps c && echo "Hello" && read NAME && echo "Hi $NAME."'
         from ilogue.fexpect import expect, expecting, run
         import fabric
         expectation =  expect('Hello','answer')
-        backupenv = fabric.state.env
+        backupenv = dict(fabric.state.env)
         fabric.state.env.shell = 'sh -c'
         with expecting(expectation):
             output = run(cmd)
-        fabric.state.env = backupenv
+        fabric.state.env.update(backupenv)
         self.assertIn('00 sh',output)
 
     def tryOrFailOnPrompt(self,method,args):


### PR DESCRIPTION
- Sometimes Input/output error occurs pexpect in response to the output of ps.
- It has not been backed up env because a shallow copy.
