### PR TITLE
Fixed issue with fexpect sending __init__.py to remote system (instead of entire pexpect directory)

### DIFF
--- a/ilogue/fexpect/internals.py
+++ b/ilogue/fexpect/internals.py
@@ -15,13 +15,13 @@ def wrapExpectations(cmd):
     script = createScript(cmd)
     remoteScript = '/tmp/fexpect_'+shortuuid.uuid()
     import pexpect
-    pexpect_module = pexpect.__file__
-    if pexpect_module.endswith('.pyc'):
-        pexpect_module = pexpect_module[:-1]
+    pexpect_loader= pexpect.__file__
+    final_dir_index = pexpect_loader.find('pexpect') + len('pexpect')
+    pexpect_loader= pexpect_loader[:final_dir_index]
     # If mode not set explicitly, and this is run as a privileged user, 
     # later command from an unpriviliged user will fail due to the permissions
     # on /tmp/pexpect.py
-    fabric.api.put(pexpect_module,'/tmp/', mode=0777) 
+    fabric.api.put(pexpect_loader,'/tmp/', mode=0777) 
     fabric.api.put(StringIO(script),remoteScript)
     wrappedCmd = 'python '+remoteScript
     return wrappedCmd


### PR DESCRIPTION
Method wrapExpectations() in internals.py is responsible for uploading the pexpect library to the remote system. The current code assumes that pexpect is a single file (pexpect.py) when instead pexpect is a package containing several files (see https://github.com/pexpect/pexpect/tree/master/pexpect). When it tries to locate pexpect, it selects pexpect/**init**.py instead of the entire folder. When fexpect tries to run the remote script, the script fails to import pexpect and dies.

This commit modifies the code so that it correctly pushes the entire pexpect directory to the remote system. 
