### PR TITLE
Mangle expections to avoid matching line twice

### DIFF
--- a/ilogue/fexpect/internals.py
+++ b/ilogue/fexpect/internals.py
@@ -58,6 +58,7 @@ def createScript(cmd):
         ifkeyw = 'if' if i == 0 else 'elif'
         s+= "\t\t{0} i == {1}:\n".format(ifkeyw,i)
         s+= "\t\t\tchild.sendline('{0}')\n".format(e[1])
+        s+= "\t\t\texpectations[i]=\"__MANGLE__\"\n\n"
         if len(e)>2:
             s+= "\t\t\tsleep({0})\n".format(e[2])
             s+= "\t\t\tprint('Exiting fexpect for expected exit.')\n"

--- a/ilogue/fexpect/tests.py
+++ b/ilogue/fexpect/tests.py
@@ -138,3 +138,20 @@ class FexpectTests(unittest.TestCase):
         except SystemExit as promptAbort:
             self.fail("There was an unexpected (password) prompt.")
         return result 
+
+    def test_multimatch(self):
+        """ Match same prompt but with different responses """
+
+        cmd =  'echo "name" && read NAME1 && echo "name is $NAME1" && echo "name" && read NAME2 && echo "name is $NAME2"'
+
+        from ilogue.fexpect import expecting, expect, run
+
+        expectation = []
+        expectation += expect('name', 'Ford')
+        expectation += expect('name', 'Arthur')
+
+        with expecting(expectation):
+            output = run(cmd)
+
+        self.assertIn('Ford', output)
+        self.assertIn('Arthur', output)


### PR DESCRIPTION
After a succesful match mangle the matched expectation to avoid
a second match.  This allows you to match the same string multiple times
 with different responses.

From pexpect docs:
    expect(self, pattern, timeout=-1, searchwindowsize=None)

```
If you pass a list of patterns and more than one matches, the first
match
in the stream is chosen. If more than one pattern matches at that point,
the leftmost in the pattern list is chosen. For example::

    # the input is 'foobar'
    index = p.expect (['bar', 'foo', 'foobar'])
    # returns 1 ('foo') even though 'foobar' is a "better" match
```
